### PR TITLE
Add .replace() functions to translated text

### DIFF
--- a/google_translate_pdfs/file_management.py
+++ b/google_translate_pdfs/file_management.py
@@ -54,7 +54,10 @@ def get_file_text(file_name):
         for i, image_file in enumerate(image_file_list):
             text = str((image_to_string(Image.open(image_file))))
             file_text.append(
-                (i + 1, text.replace("\t+", " ").replace("\n", " "))
+                (
+                    i + 1,
+                    text.replace("\t+", " ").replace("\n", " "),
+                )
             )
 
     return file_text

--- a/google_translate_pdfs/translation.py
+++ b/google_translate_pdfs/translation.py
@@ -6,6 +6,8 @@ import six
 from google.cloud import translate_v2 as translate
 from util.constants import ENCODING_STANDARD
 
+KEY_TRANSLATED_TEXT = "translatedText"
+
 
 def gcloud_translate(src_lang, target_lang, text):
     """
@@ -34,7 +36,11 @@ def gcloud_translate(src_lang, target_lang, text):
         resp = translate_client.translate(
             t, source_language=src_lang, target_language=target_lang
         )
-        if resp["translatedText"]:
-            results.append(resp["translatedText"])
+        if resp[KEY_TRANSLATED_TEXT]:
+            results.append(
+                resp[KEY_TRANSLATED_TEXT]
+                .replace("&#39;", "'")
+                .replace("&quot;", '"')
+            )
 
     return results


### PR DESCRIPTION
## What does this pull request add?
I added two `.replace()` statements to the translated text that take care of the overly prevalent `&#39;` and `&quot;` strings.

## Are there any technical things that should be noted for this PR?
Nay.

## How was it tested?
- [x] Manually tested code.
- [x] I ran `pylint` and have made the bulk of changes that it has requested.
- [x] I ran the `black` formatter and pushed the changes.
