### PR TITLE
Add `Lint` GitHub Action logic

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,5 @@
 PUT THE `make test` OUTPUT HERE
 ```
 - [ ] I ran `make lint` and have made the bulk of changes that it has requested.
-- [ ] I ran `make format` and pushed the changes.
+- [ ] The `Lint` GitHub Action step is passing.
+  - Manually run `make format` to correct the errors.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,6 @@ jobs:
   Black:
     runs-on: ubuntu-latest
     steps:
-      - name: Black
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
@@ -17,7 +16,6 @@ jobs:
   ISort:
     runs-on: ubuntu-latest
     steps:
-      - name: isort
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+on:
+  - push
+  - pull_request
+jobs:
+  Black:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Black
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        with:
+          src: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
+          options: --check --verbose
+          version: ^23.1.0
+  ISort:
+    runs-on: ubuntu-latest
+    steps:
+      - name: isort
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+      - uses: isort/isort-action@master
+        with:
+          configuration: --check-only --diff
+          requirementsFiles: pyproject.toml
+          sortPaths: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           configuration: --check-only --diff
           requirementsFiles: pyproject.toml
-          sortPaths: ./test/ ./pdf_parser ./google_translate_pdfs/ ./geocode_verifier/ ./util/
+          sortPaths: ./test/ ./pdf_parser/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           configuration: --check-only --diff
           requirementsFiles: pyproject.toml
-          sortPaths: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
+          sortPaths: ./test/ ./pdf_parser ./google_translate_pdfs/ ./geocode_verifier/ ./util/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          src: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
           options: --check --verbose
           version: ~= 23.1.0
   ISort:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: 3.12
-      - uses: https://github.com/psf/black@stable
+      - uses: psf/black@stable
         with:
           src: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
           options: --check --verbose
@@ -22,8 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: 3.12
       - uses: isort/isort-action@master
         with:
           configuration: --check-only --diff

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,18 @@
 name: Lint
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   Black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+        with:
+          python-version: 3.12
+      - uses: https://github.com/psf/black@stable
         with:
           src: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
           options: --check --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           src: ./test/ ./google_translate_pdfs/ ./geocode_verifier/ ./util/
           options: --check --verbose
-          version: ^23.1.0
+          version: ~= 23.1.0
   ISort:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@
 
 .PHONY: format
 format:
-	isort test/ google_translate_pdfs/ util/ --line-length=80 --profile=black
-	black test/ google_translate_pdfs/ util/ --line-length=80
+	isort test/ pdf_parser/ google_translate_pdfs/ util/ --line-length=80 --profile=black
+	black test/ pdf_parser/ google_translate_pdfs/ util/ --line-length=80
 
 .PHONY: lint
 lint:
-	pylint test/ google_translate_pdfs/ util/
+	pylint test/ pdf_parser/ google_translate_pdfs/ util/
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 .PHONY: format
 format:
-	isort test/ pdf_parser/ google_translate_pdfs/ util/ --line-length=80 --profile=black
-	black test/ pdf_parser/ google_translate_pdfs/ util/ --line-length=80
+	isort test/ pdf_parser/ google_translate_pdfs/ util/
+	black test/ pdf_parser/ google_translate_pdfs/ util/
 
 .PHONY: lint
 lint:

--- a/pdf_parser/file_management.py
+++ b/pdf_parser/file_management.py
@@ -1,10 +1,6 @@
 import os
 
-from util.constants import (
-    ENCODING_STANDARD,
-    FILE_OPEN_WRITE,
-    EXTENSION_TXT,
-)
+from util.constants import ENCODING_STANDARD, EXTENSION_TXT, FILE_OPEN_WRITE
 
 FOLDER_OUTPUT = os.getcwd() + "/pdf_parser/data/output/"
 
@@ -12,8 +8,8 @@ FOLDER_OUTPUT = os.getcwd() + "/pdf_parser/data/output/"
 def write_file_text_to_txt(original_file_name, text):
     name, _ = os.path.splitext(original_file_name)
     with open(
-            FOLDER_OUTPUT + name + EXTENSION_TXT,
-            FILE_OPEN_WRITE,
-            encoding=ENCODING_STANDARD,
+        FOLDER_OUTPUT + name + EXTENSION_TXT,
+        FILE_OPEN_WRITE,
+        encoding=ENCODING_STANDARD,
     ) as text_file:
         text_file.writelines(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,6 @@ license = "MIT"
 readme = "README.md"
 packages = [{include = "one_offs"}]
 
-[tool.black]
-line-length = 80
-
-[tool.isort]
-profile= "black"
-
 [tool.poetry.dependencies]
 python = "^3.11"
 black = "^23.1.0"
@@ -23,6 +17,11 @@ pytesseract = "^0.3.10"
 pdf2image = "^1.16.3"
 isort = "^5.12.0"
 
+[tool.black]
+line-length = 80
+
+[tool.isort]
+profile= "black"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{include = "one_offs"}]
 line-length = 80
 
 [tool.isort]
-line-length = 80
+profile= "black"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ line-length = 80
 
 [tool.isort]
 profile= "black"
+line_length = 80
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "one-offs"
 version = "0.1.0"
-description = ""
+description = "This repository will house any one-off side projects I create on behalf of others or small scripts I write to accomplish x or y tasks."
 authors = ["michplunkett <michplunkett@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ packages = [{include = "one_offs"}]
 [tool.black]
 line-length = 80
 
+[tool.isort]
+line-length = 80
+
 [tool.poetry.dependencies]
 python = "^3.11"
 black = "^23.1.0"


### PR DESCRIPTION
## What does this pull request add?
It shifts the parameters for running `black` and `isort` to the `pyproject.toml` file and adds a GitHub Action step for validating that formatting happened.

## Are there any technical things that should be noted for this PR?
Nay.

## How was it tested?
- [x] I ran `make lint` and have made the bulk of changes that it has requested.
- [x] The `Lint` GitHub Action step is passing.
  - Manually run `make format` to correct the errors.
